### PR TITLE
Add optional browser url argument to emrun

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1768,6 +1768,8 @@ def run():
       if browser_exe == 'cmd':
         url = url.replace('&', '^&')
       url = url.replace('0.0.0.0', 'localhost')
+      if options.browser_url:
+        url = options.browser_url
       browser += browser_args + [url]
 
   if options.kill_start:
@@ -1823,10 +1825,6 @@ def run():
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
   if options.run_browser:
-    if options.browser_url:
-        url = options.browser_url
-        logv('Connecting browser to URL ' + url)
-        browser += browser_args + [url]
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
     #   Workaround an issue where passing 'cmd /C start' is not able to detect

--- a/emrun.py
+++ b/emrun.py
@@ -1526,6 +1526,9 @@ def parse_args():
 
   parser.add_argument('--verbose', action='store_true',
                       help='Enable verbose logging from emrun internal operation.')
+  
+  parser.add_argument('--browser_url', default='',
+                      help='Specifies the address the web browser would connect to.')
 
   parser.add_argument('--hostname', default=default_webserver_hostname,
                       help='Specifies the hostname the server runs in.')
@@ -1820,6 +1823,10 @@ def run():
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
   if options.run_browser:
+    if options.browser_url:
+        url = options.browser_url
+        logv('Connecting browser to URL ' + url)
+        browser += browser_args + [url]
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
     #   Workaround an issue where passing 'cmd /C start' is not able to detect


### PR DESCRIPTION
Adds an optional browser url argument to emrun to automatically open the specified browser url rather than the default browser url. This is necessary for WPMF because we want to be able to open Emunittest on one port while running the emrun server on a separate port.