### PR TITLE
Fix browser url option

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1825,10 +1825,6 @@ def run():
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
   if options.run_browser:
-    if options.browser_url:
-        url = options.browser_url
-        logv('Connecting browser to URL ' + url)
-        browser += browser_args + [url]
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
     #   Workaround an issue where passing 'cmd /C start' is not able to detect

--- a/emrun.py
+++ b/emrun.py
@@ -1681,11 +1681,14 @@ def run():
     url = options.browser_url
 
   if not file_to_serve_is_url:
+    
+    if not options.browser_url:
+      hostname = socket.gethostbyname(socket.gethostname()) if options.android else options.hostname
+      # create url for browser after opening the server so we have the final port number in case we are binding to port 0
+      url = 'http://' + hostname + ':' + str(options.port) + '/' + url
+
     if len(options.cmdlineparams):
       url += '?' + '&'.join(options.cmdlineparams)
-    hostname = socket.gethostbyname(socket.gethostname()) if options.android else options.hostname
-    # create url for browser after opening the server so we have the final port number in case we are binding to port 0
-    url = 'http://' + hostname + ':' + str(options.port) + '/' + url
 
   if options.android:
     if options.run_browser or options.browser_info:

--- a/emrun.py
+++ b/emrun.py
@@ -1677,6 +1677,9 @@ def run():
     # to support binding to port zero we must allow the server to open to socket then retrieve the final port number
     options.port = httpd.socket.getsockname()[1]
 
+  if options.browser_url:
+    url = options.browser_url
+
   if not file_to_serve_is_url:
     if len(options.cmdlineparams):
       url += '?' + '&'.join(options.cmdlineparams)
@@ -1767,9 +1770,8 @@ def run():
       # use ^ to escape them.
       if browser_exe == 'cmd':
         url = url.replace('&', '^&')
-      url = url.replace('0.0.0.0', 'localhost')
-      if options.browser_url:
-        url = options.browser_url
+      if not options.browser_url:
+        url = url.replace('0.0.0.0', 'localhost')
       browser += browser_args + [url]
 
   if options.kill_start:

--- a/emrun.py
+++ b/emrun.py
@@ -1825,6 +1825,10 @@ def run():
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
   if options.run_browser:
+    if options.browser_url:
+        url = options.browser_url
+        logv('Connecting browser to URL ' + url)
+        browser += browser_args + [url]
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
     #   Workaround an issue where passing 'cmd /C start' is not able to detect


### PR DESCRIPTION
The browser_url option wasn't working correctly in all cases. When `options.cmdlineparams` were specified and the browser_url was also specified, the cmdlineparams were getting overwritten because they were being appended to the url earlier in the file. This PR moves up changing the url to be the browser_url (in the case that it is set by the user) to before the line where the cmdlineparams are appended to the url.

Manually tested:

1. When running Emunittest with run.py:
- The correct url is opened when we specify a browser_url and no cmdlineparams
- The correct url is opened when we specify a browser_url and cmdlineparams
- The correct url is opened when we don't specify a browser_url and don't specify cmdlineparams
- The correct url is opened when we don't specify a browser_url and do specify cmdlineparams

2. When running Emunittest with emrun.py:
- The correct url is still opened when a browser_url is specified
- The correct url is still opened when a browser_url is not specified

Note: While making this change I also noticed that `run.py` will automatically close the Emunittest window after the autoruns are done only when a browser_url is NOT specified. So I need do some investigation to figure out why it doesn't close on its own when the browser_url has a value.