### PR TITLE
Fix opening demolist

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -1825,10 +1825,6 @@ def run():
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
   if options.run_browser:
-    if options.browser_url:
-        url = options.browser_url
-        logv('Connecting browser to URL ' + url)
-        browser += browser_args + [url]
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
     #   Workaround an issue where passing 'cmd /C start' is not able to detect

--- a/emrun.py
+++ b/emrun.py
@@ -1825,6 +1825,10 @@ def run():
     else:
       browser_stderr_handle = open(options.log_stderr, 'a')
   if options.run_browser:
+    if options.browser_url:
+        url = options.browser_url
+        logv('Connecting browser to URL ' + url)
+        browser += browser_args + [url]
     logv("Starting browser: %s" % ' '.join(browser))
     # if browser[0] == 'cmd':
     #   Workaround an issue where passing 'cmd /C start' is not able to detect

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ var browserInfo = null;
 // Aggregates all test results by test name, e.g. allTestResultsByKey['angrybots'] is an array containing results of each run of that demo.
 var allTestResultsByKey = {};
 
-var testData = await fetch(`${window.location.href}/demo_list.json`);
+var host = window.location.protocol + "//" + window.location.host;
+var testData = await fetch(`${host}/demo_list.json`);
 var tests = await testData.json();
 
 // If running on a mobile browser, filter out showing the tests that can't be run on a mobile browser.

--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ var browserInfo = null;
 // Aggregates all test results by test name, e.g. allTestResultsByKey['angrybots'] is an array containing results of each run of that demo.
 var allTestResultsByKey = {};
 
-var host = window.location.protocol + "//" + window.location.host;
-var testData = await fetch(`${host}/demo_list.json`);
+const {host, protocol} = window.location;
+var testData = await fetch(`${protocol}//${host}/demo_list.json`);
 var tests = await testData.json();
 
 // If running on a mobile browser, filter out showing the tests that can't be run on a mobile browser.


### PR DESCRIPTION
The frontend was unable to access the demolist.json file when running Emunittest with `run.py` because `run.py` adds additional command line parameters and index.html to the end of the url. This PR is for changing the path to the demolist.json file to just include the protocol and hostname.

Manually tested and confirmed the following:
1. Running Emunittest with emrun.py:
- Still tries to find demolist.json using the correct url

2. Running Emunittest with run.py:
- Tries to find demolist.json using the correct url

3. Running Emunittest with start_server
- Tries to find demolist.json using the correct url

Since the above are all true now, the demos are successfully loaded into the index.html page of Emunittest in each case.