### PR TITLE
Send exit/print functions to browser when autoRun is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,8 +275,9 @@ function post(msg) {
   http.open("POST", "stdio.html", true);
   http.send(msg);
 }
-// If the address contains localhost, or we are running the page from port 6931, we can assume we're running the test runner and should post stdout logs.
-if (document.URL.indexOf("localhost") != -1 || document.URL.indexOf(":6931/") != -1) {
+
+// If autoRun is enabled, assume we want to automatically close the browser the test(s) finish
+if (autoRun) {
   var emrun_http_sequence_number = 1;
   emrun_exit = function() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; };
   emrun_print = function(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); }
@@ -285,7 +286,7 @@ if (document.URL.indexOf("localhost") != -1 || document.URL.indexOf(":6931/") !=
   // Notify emrun web server that this browser has successfully launched the page.
   post('^pageload^');
 } else {
-  // emrun is not being used, no-op.
+  // otherwise, don't pass any exit/print functions, and the browser stays open
   emrun_exit = function() {}
   emrun_print = function(text) {}
   emrun_printErr = function(text) {}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ let {
   emrun_printErr,
 } = window;
 
+const autoRunEnabled = location.search.toLowerCase().indexOf('autorun') != -1;
+
 (function createEventListeners() {
   document.getElementById('show-system-information').addEventListener('click', () => {
     toggleVisible('show-system-information', 'system_information');
@@ -29,7 +31,7 @@ if (location.search.toLowerCase().indexOf('numtimes=') != -1) {
 
 document.getElementById('noVsync').checked = (location.search.toLowerCase().indexOf('novsync') != -1);
 document.getElementById('fakeGL').checked = (location.search.toLowerCase().indexOf('fakeGL') != -1);
-if (location.search.toLowerCase().indexOf('nocpuprofiler') != -1 || location.search.toLowerCase().indexOf('autorun') != -1) {
+if (location.search.toLowerCase().indexOf('nocpuprofiler') != -1 || autoRunEnabled) {
   document.getElementById('cpuProfiler').checked = false;
 }
 document.getElementById('tortureMode').checked = (location.search.toLowerCase().indexOf('torturemode') != -1);
@@ -277,7 +279,7 @@ function post(msg) {
 }
 
 // If autoRun is enabled, assume we want to automatically close the browser the test(s) finish
-if (autoRun) {
+if (autoRunEnabled) {
   var emrun_http_sequence_number = 1;
   emrun_exit = function() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; };
   emrun_print = function(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); }
@@ -422,7 +424,7 @@ function writeFullTestResults() {
       if (t.result.result != 'PASS') ++numTestsFailed;
     }
   }
-  if (numTestsRun > 0 && allTestsRun && location.search.toLowerCase().indexOf('autorun') != -1) emrun_exit(numTestsFailed);
+  if (numTestsRun > 0 && allTestsRun && autoRunEnabled) emrun_exit(numTestsFailed);
 }
 
 var fullTestLog = ' Run Date         | Test Name                             | Total time (lower is better) |   FPS | CPU Time |   WebGL CPU Time | WebGL calls/frame| CPU Idle | Page load time | # of janked frames | Used JS Mem\n';
@@ -516,7 +518,7 @@ function toggleVisible(buttionId, id) {
 }
 
 function autoRun() {
-  if (!currentlyRunningTest && location.search.toLowerCase().indexOf('autorun') != -1) {
+  if (!currentlyRunningTest && autoRunEnabled) {
     runSelectedTests();
   }
 }


### PR DESCRIPTION
Currently the browser will only close after tests are run using `run.py` if the url contains localhost or we are running it on port 6931. We want to change this to have any url automatically close after tests are run when the `autorun` field is enabled (which it always is and only is when running Emunittest with `run.py`). This is necessary because we are now starting to run Emunittest with different browser urls and want them to be able to automatically close.

Tested that:

- `start_server` works as expected - browser does not automatically close after running a test
- `emrun.py` works as expected - browser does not automatically close after running a test
- `run.py` works as expected - browser automatically closes after running a test (because autorun is enabled)

These manual tests were successful and test on Chrome and Firefox on a Mac M1 laptop