### PR TITLE
Merge updates from main Emunittest branch into WPMF

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -659,7 +659,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
     fs = os.fstat(f.fileno())
     self.send_header("Content-Length", str(fs.st_size))
     self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
-    self.send_header('Cache-Control', 'no-cache, must-revalidate')
+    self.send_header('Cache-Control', 'no-cache, no-store, must-revalidate')
     self.send_header('Connection', 'close')
     self.send_header('Expires', '-1')
     self.send_header('Access-Control-Allow-Origin', '*')
@@ -710,7 +710,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
       data = {'system': system_info, 'browser': browser_info}
       self.send_response(200)
       self.send_header('Content-type', 'application/json')
-      self.send_header('Cache-Control', 'no-cache, must-revalidate')
+      self.send_header('Cache-Control', 'no-cache, no-store, must-revalidate')
       self.send_header('Connection', 'close')
       self.send_header('Expires', '-1')
       self.end_headers()
@@ -754,7 +754,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
 
     self.send_response(200)
     self.send_header('Content-type', 'text/plain')
-    self.send_header('Cache-Control', 'no-cache, must-revalidate')
+    self.send_header('Cache-Control', 'no-cache, no-store, must-revalidate')
     self.send_header('Connection', 'close')
     self.send_header('Expires', '-1')
     self.end_headers()


### PR DESCRIPTION
The main Emunittest branch has a bug fix that ensures that Emunittest is automatically closed any time `autoRun` is specified. We want to be able to use this in the WPMF branch since results will not send to Big Query until the process is closed. Previously the browser process was closed based on whether the url contained `localhost` or was running on port 6931, which isn't a good determining factor on whether the browser should be closed after the process is done running. It makes more sense for the browser to automatically close when the user requests that a test be automatically run.